### PR TITLE
Fix Crash

### DIFF
--- a/MobileEngage/NSDictionary+MobileEngage.h
+++ b/MobileEngage/NSDictionary+MobileEngage.h
@@ -6,6 +6,6 @@
 
 @interface NSDictionary (MobileEngage)
 
-- (NSString *)messageId;
+- (nullable NSString*)messageId;
 
 @end

--- a/MobileEngage/NSDictionary+MobileEngage.m
+++ b/MobileEngage/NSDictionary+MobileEngage.m
@@ -9,17 +9,26 @@
 
 @implementation NSDictionary (MobileEngage)
 
-- (NSString *)messageId {
-    NSString *sid;
-    NSString *customData = self[PushwooshMessageCustomDataKey];
-    NSData *data = [customData dataUsingEncoding:NSUTF8StringEncoding];
-    if (data) {
-        NSDictionary<NSString *, id> *customDataDict = [NSJSONSerialization JSONObjectWithData:data
-                                                                                       options:NSJSONReadingAllowFragments
-                                                                                         error:nil];
-        sid = customDataDict[MobileEngageSIDKey];
+- (nullable NSString *)messageId {
+    id customData = self[PushwooshMessageCustomDataKey];
+
+    if([customData isKindOfClass:[NSString class]]){
+        NSString *sid;
+
+        NSData *data = [customData dataUsingEncoding:NSUTF8StringEncoding];
+        if (data) {
+            NSDictionary<NSString *, id> *customDataDict = [NSJSONSerialization JSONObjectWithData:data
+                                                                                           options:NSJSONReadingAllowFragments
+                                                                                             error:nil];
+            sid = customDataDict[MobileEngageSIDKey];
+        }
+        return sid;
+        
+    }else if([customData isKindOfClass:[NSDictionary<NSString*, NSString*> class]]){
+        return customData[MobileEngageSIDKey];
     }
-    return sid;
+    return nil;
 }
+
 
 @end

--- a/MobileEngageTests/NSDictionary+MobileEngageTests.m
+++ b/MobileEngageTests/NSDictionary+MobileEngageTests.m
@@ -31,6 +31,13 @@ SPEC_BEGIN(NSDictionaryMobileEngageTests)
             };
             [[[dict messageId] should] equal:@"123456789"];
         });
+
+        it(@"should be able to parse whats actually returned", ^{
+            NSDictionary *dict = @{
+                                   @"u": @{@"sid": @"123456789"}
+                                   };
+            [[[dict messageId] should] equal:@"123456789"];
+        });
     });
 
 SPEC_END


### PR DESCRIPTION
Heyo, when I implemented 
```
- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler{
     [MobileEngage trackMessageOpenWithUserInfo:userInfo];
}
```
And sent a test notification, the app crashed :(, I tracked it down the messageID extension, it thought it was handling json but it was dictionary.