### PR TITLE
Fix `Pointer is missing a nullability type specifier (_Nonnull, _Nullable, or _Null_unspecified)` error on Xcode 10.2

### DIFF
--- a/MobileEngage/MobileEngage.h
+++ b/MobileEngage/MobileEngage.h
@@ -10,9 +10,9 @@
 @class MEConfig;
 @protocol MobileEngageStatusDelegate;
 
-typedef void(^MESourceHandler)(NSString *source);
-
 NS_ASSUME_NONNULL_BEGIN
+
+typedef void(^MESourceHandler)(nullable NSString *source);
 
 @interface MobileEngage : NSObject
 

--- a/MobileEngage/MobileEngage.h
+++ b/MobileEngage/MobileEngage.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void(^MESourceHandler)(nullable NSString *source);
+typedef void(^MESourceHandler)(NSString * _Nullable source);
 
 @interface MobileEngage : NSObject
 


### PR DESCRIPTION
![Screenshot 2019-04-04 at 17 02 49](https://user-images.githubusercontent.com/9446070/55954633-82588a80-5c5f-11e9-80ae-f3762c3ea128.png)
