### PR TITLE
Fix crash on inserting nil object

### DIFF
--- a/MobileEngage/RequestTools/MERequestFactory.m
+++ b/MobileEngage/RequestTools/MERequestFactory.m
@@ -218,10 +218,9 @@
     EMSRequestModel *requestModel = [EMSRequestModel makeWithBuilder:^(EMSRequestModelBuilder *builder) {
             [builder setUrl:url];
             [builder setMethod:method];
-            NSMutableDictionary *payload = [@{
-                @"application_id": requestContext.config.applicationCode,
-                @"hardware_id": [EMSDeviceInfo hardwareId]
-            } mutableCopy];
+            NSMutableDictionary *payload = [NSMutableDictionary new];
+            payload[@"application_id"] = requestContext.config.applicationCode;
+            payload[@"hardware_id"] = [EMSDeviceInfo hardwareId];
 
             if (requestContext.appLoginParameters.contactFieldId && requestContext.appLoginParameters.contactFieldValue) {
                 payload[@"contact_field_id"] = requestContext.appLoginParameters.contactFieldId;


### PR DESCRIPTION
This PR is about fixing the crashes I get from Firebase. These crashes are pointing to MERequestFactory:
```
MERequestFactory.m - Line 221
__85+[MERequestFactory requestModelWithUrl:method:additionalPayloadBlock:requestContext:]_block_invoke + 221
```
Probably, this is happening if
` [EMSDeviceInfo hardwareInfo]` from [CoreSDK](https://github.com/emartech/ios-core-sdk) returns nil, and this actually could be, because under the hood the `hardwareInfo` method calls internal method:
```objc
+ (NSString *)getNewHardwareId {
    if ([[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]) {
        return [[[ASIdentifierManager sharedManager] advertisingIdentifier]
            UUIDString];
    }
    return [[[UIDevice currentDevice] identifierForVendor] UUIDString];
}
```

So if a user turns off the add tracking and reboots the device(or other cases) then the
`identifierForVendor` could be nil as described in [docs](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor)


P.S. I've also tried to add a unit test to check this situation but following code couldn't stub the method inside pod library:
```objc
[[EMSDeviceInfoMock class] stub:@selector(hardwareId) andReturn:nil];
```